### PR TITLE
Add manala update check

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,19 +1,59 @@
-setup-manala
-============
+# Setup Manala Action
 
-This action download and install the Manala binary and make it available in your
-workflows.
+This action downloads and installs the Manala binary and makes it available in
+your workflows.
 
-Usage
------
+## Usage
 
 ```yaml
 
 steps:
-
   - uses: actions/checkout@v2
   - uses: manala/setup-manala-action@master
 
   - name: Run Manala update
     run: manala update
+```
+
+## Checks
+
+Additionally, the action provides some common `checks` you can opt-in using JSON format.
+
+### `update` check
+
+Use this check in your workflow, to ensure any `.manala.yaml` changes are 
+properly reflected in your PRs, or get a failure otherwise:
+
+```yaml
+  - uses: manala/setup-manala-action@master
+    with:
+      checks: '["update"]'
+```
+
+Here is a suggested `.github/workflows/.manala-update.yaml` workflow:
+
+```yaml 
+name: Manala update
+
+on:
+  push:
+    branches: [master]
+    paths: ['.manala.yaml']
+  pull_request:
+    types: [opened, synchronize, ready_for_review]
+    paths: ['.manala.yaml']
+
+jobs:
+  manala-update:
+    runs-on: ubuntu-latest
+    timeout-minutes: 2
+    steps:
+
+      - name: 'Checkout head'
+        uses: actions/checkout@v2
+
+      - name: 'Check .manala changes are up-to-date'
+        uses: manala/setup-manala-action@master
+        with:
+          checks: '["update"]'
 ```

--- a/action.yml
+++ b/action.yml
@@ -1,24 +1,48 @@
 name: Setup Manala
-description: Setup the Manala binary adn add it to the PATH
+description: Setup the Manala binary and run extra checks
 author: 'Manala'
 branding:
   color: orange
   icon: settings
 
-#inputs:
-#  version:
-#    description: 'The Manala binary version'
-#    required: false
-#    default: ~
+inputs:
+  checks:
+    description: 'Checks to run. Must be a JSON array. Available checks: ["update"]'
+    required: false
+    default: '[]'
 
 runs:
   using: composite
   steps:
 
-    - name: Download & Install the Manala binary
+    - name: Setup
       shell: bash
-      run: curl -sfL https://raw.githubusercontent.com/manala/manala/master/godownloader.sh | sh
+      run: |
+        if ! command -v manala &> /dev/null; then
+          echo "::group::Download & Install the Manala binary"
+            curl -sfL https://raw.githubusercontent.com/manala/manala/master/godownloader.sh | sh
+            echo "./bin/" >> $GITHUB_PATH
+          echo "::endgroup::"
+        fi
 
-    - name: Add to PATH
+    - name: Checks
       shell: bash
-      run: echo "./bin/" >> $GITHUB_PATH
+      run: |
+        status=0
+
+        if [ true = ${{ contains(fromJSON(inputs.checks), 'update') }} ]; then
+          echo "::group::Running \"update\" check"
+            manala update
+            git add --all .manala/
+
+            if git diff-index --quiet HEAD --; then
+              echo "No changes detected"
+            else
+              echo "::warning file=.manala.yaml,line=1,col=0::Manala detected some changes that are not reflected in your commit. Inspect those changes in the logs or run `manala up` and commit these changes on your branch."
+              git diff HEAD --color=always
+              status=1
+            fi
+          echo "::endgroup::"
+        fi
+
+        exit $status


### PR DESCRIPTION
Add a check you can opt-in in this action, so you can easily check in your workflow is the manala changes are properly reflected in your PR and get a failure otherwise (a preferred approach compared to auto-commit which can be annoying).

![Capture d’écran 2020-11-26 à 12 53 09](https://user-images.githubusercontent.com/2211145/100347885-647f9b00-2fe6-11eb-83e9-0b6ecd639191.png)
![Capture d’écran 2020-11-26 à 12 53 21](https://user-images.githubusercontent.com/2211145/100347892-66495e80-2fe6-11eb-8d4a-fc37f3befac1.png)
![Capture d’écran 2020-11-26 à 12 53 56](https://user-images.githubusercontent.com/2211145/100347951-76f9d480-2fe6-11eb-84ae-e87e6ee296fa.png)
